### PR TITLE
Avoid string allocations from string formatting and ToString calls in RuntimeAssert

### DIFF
--- a/Runtime/DIContainer/DiContainer.cs
+++ b/Runtime/DIContainer/DiContainer.cs
@@ -169,14 +169,14 @@ namespace UJect
             if (resolvedInstances.TryGetValue(key, out var resolvedDependency))
             {
                 dependency = (TType)resolvedDependency;
-                AssertObjectIsAlive(dependency, $"Null dependency detected in: {this}. It should have been unregistered!");
+                AssertObjectIsAlive(dependency, "Null dependency detected in: {0}. It should have been unregistered!", this);
                 return true;
             }
 
             if (parentContainer != null && parentContainer.TryGetDependencyInternal<TType>(key, out var parentDependency))
             {
                 dependency = parentDependency;
-                AssertObjectIsAlive(dependency, $"Null dependency detected in parent: {parentContainer}. It should have been unregistered!");
+                AssertObjectIsAlive(dependency, "Null dependency detected in parent: {0}. It should have been unregistered!", parentContainer);
                 return true;
             }
 

--- a/Runtime/Utilities/RuntimeAssert.cs
+++ b/Runtime/Utilities/RuntimeAssert.cs
@@ -29,5 +29,13 @@ namespace UJect.Assertions
                 throw new InvalidOperationException(message);
             }
         }
+
+        public static void AssertObjectIsAlive(object obj, string message, object arg)
+        {
+            if (LifetimeCheck.IsNullOrDestroyed(obj))
+            {
+                throw new InvalidOperationException(string.Format(message, arg));
+            }
+        }
     }
 }


### PR DESCRIPTION
When calling RuntimeAssert.AssertObjectIsAlive, the string formatting and ToString calls associated with it only need to occur if the assertion fails and the exception is thrown. This changes the pattern used in RuntimeAssert to allow a format string with an argument to be passed, avoiding any allocations unless the assertion fails.