### PR TITLE
Adding ability to bind multiple interfaces to the same implementation

### DIFF
--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0f7bdcb77a24896838d3ea226b80b34
+timeCreated: 1669674137

--- a/Editor/DiBinders.tt
+++ b/Editor/DiBinders.tt
@@ -1,0 +1,140 @@
+﻿<#@ template language="C#" #>
+<#@ assembly name="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" #>
+<#@ import namespace="System.Linq" #>
+<#@ output extension="g.cs"#>
+using System;
+using UJect.Factories;
+using UJect.Resolvers;
+using Uject.Utilities;
+
+namespace UJect
+{
+<#
+    for (int i = 1; i <= 5; i++)
+    {
+        GenerateBinder(i);
+    }
+    
+    void GenerateBinder(int numInterfaces)
+    {
+        var interfaceNames = Enumerable.Range(0, numInterfaces).Select(i => $"TInterface{i + 1}");
+        var joinedInterfaces = string.Join(", ", interfaceNames);
+
+        var interfaceType = $"IDiBinder<{joinedInterfaces}>";
+
+#>
+
+    public class DiBinder<<#=joinedInterfaces#>> : <#=interfaceType#>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public <#=interfaceType#> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : <#=joinedInterfaces#>
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  <#=joinedInterfaces#>
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  <#=joinedInterfaces#>
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  <#=joinedInterfaces#>
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  <#=joinedInterfaces#>
+        {
+<#
+        foreach (var interfaceName in interfaceNames)
+        {
+#>
+            dependencies.InstallFactoryBinding<<#=interfaceName#>, TImpl>(customId, factoryImpl);
+<#
+        }
+#>
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  <#=joinedInterfaces#>
+        {
+<#
+        foreach (var interfaceName in interfaceNames)
+        {
+#>
+            dependencies.InstallBindingInternal<<#=interfaceName#>, TImpl>(customId, resolver);
+<#
+        }
+#>
+        }
+    }
+<#
+    }
+#>
+}

--- a/Editor/DiBinders.tt.meta
+++ b/Editor/DiBinders.tt.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: df4d2d1f8d404a8b9b4f82b92e8e0b27
+timeCreated: 1669681662

--- a/Editor/DiBindingInterfaces.tt
+++ b/Editor/DiBindingInterfaces.tt
@@ -1,0 +1,91 @@
+﻿<#@ template language="C#" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="g.cs"#>
+
+using System;
+using UJect.Factories;
+using UJect.Resolvers;
+using Uject.Utilities;
+
+namespace UJect
+{
+<#
+    for (int i = 1; i <= 5; i++)
+    {
+        GenerateBinder(i);
+    }
+    
+    void GenerateBinder(int numInterfaces)
+    {
+        var interfaceNames = new List<string>();
+        var inInterfaceNames = new List<string>();
+        for (int i = 0; i < numInterfaces; i++)
+        {
+            var interfaceName = $"TInterface{i + 1}";
+            interfaceNames.Add(interfaceName);
+            inInterfaceNames.Add($"in {interfaceName}");
+            
+        }
+        var joinedIns = string.Join(", ", inInterfaceNames);
+        var joinedInterfaces = string.Join(", ", interfaceNames);
+#>
+
+    public interface IDiBinder<<#=joinedIns#>> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<<#=joinedInterfaces#>> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : <#=joinedInterfaces#>;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : <#=joinedInterfaces#>;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : <#=joinedInterfaces#>;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : <#=joinedInterfaces#>;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : <#=joinedInterfaces#>;
+    }
+<#
+    }
+#>
+}

--- a/Editor/DiBindingInterfaces.tt.meta
+++ b/Editor/DiBindingInterfaces.tt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff8e07f7bb31406a97fd18cfa5c78646
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/DiContainerBindingMethods.tt
+++ b/Editor/DiContainerBindingMethods.tt
@@ -1,0 +1,41 @@
+﻿<#@ template language="C#" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension="g.cs"#>
+using UJect.Assertions;
+using Uject.Utilities;
+
+namespace UJect
+{
+    public partial class DiContainer
+    {
+        #region Public Binding Interface
+<#
+    for (int i = 1; i <= 5; i++)
+    {
+        GenerateBinder(i);
+    }
+
+    void GenerateBinder(int numInterfaces)
+    {
+        var interfaceNames = new List<string>();
+        for (int i = 1; i <= numInterfaces; i++)
+        {
+            var interfaceName = $"TInterface{i}";
+            interfaceNames.Add(interfaceName);
+
+        }
+        var joinedInterfaces = string.Join(", ", interfaceNames);
+#>
+        [LibraryEntryPoint]
+        public IDiBinder<<#=joinedInterfaces#>> Bind<<#=joinedInterfaces#>>()
+        {
+            RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<<#=joinedInterfaces#>>(this);
+        }
+<#
+    }
+#>
+        #endregion Public Binding Interface
+
+    }
+}

--- a/Editor/DiContainerBindingMethods.tt.meta
+++ b/Editor/DiContainerBindingMethods.tt.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 58014bb8f91e46b28531882a409e76b4
+timeCreated: 1669681497

--- a/Editor/UJect.Editor.asmdef
+++ b/Editor/UJect.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "UJect.Editor",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "JetBrains.Annotations.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
+}

--- a/Editor/UJect.Editor.asmdef.meta
+++ b/Editor/UJect.Editor.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 01124dfdb5b042e49696e09415088b26
+timeCreated: 1669674161

--- a/Runtime/DIContainer/Binders.meta
+++ b/Runtime/DIContainer/Binders.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a83e9cd1136c4492814ac996841d3683
+timeCreated: 1669660603

--- a/Runtime/DIContainer/Binders/DiBinders.g.cs
+++ b/Runtime/DIContainer/Binders/DiBinders.g.cs
@@ -1,0 +1,521 @@
+﻿using System;
+using UJect.Factories;
+using UJect.Resolvers;
+using Uject.Utilities;
+
+namespace UJect
+{
+
+    public class DiBinder<TInterface1> : IDiBinder<TInterface1>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  TInterface1
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  TInterface1
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  TInterface1
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  TInterface1
+        {
+            dependencies.InstallFactoryBinding<TInterface1, TImpl>(customId, factoryImpl);
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  TInterface1
+        {
+            dependencies.InstallBindingInternal<TInterface1, TImpl>(customId, resolver);
+        }
+    }
+
+    public class DiBinder<TInterface1, TInterface2> : IDiBinder<TInterface1, TInterface2>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  TInterface1, TInterface2
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  TInterface1, TInterface2
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  TInterface1, TInterface2
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  TInterface1, TInterface2
+        {
+            dependencies.InstallFactoryBinding<TInterface1, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface2, TImpl>(customId, factoryImpl);
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  TInterface1, TInterface2
+        {
+            dependencies.InstallBindingInternal<TInterface1, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface2, TImpl>(customId, resolver);
+        }
+
+
+    }
+
+    public class DiBinder<TInterface1, TInterface2, TInterface3> : IDiBinder<TInterface1, TInterface2, TInterface3>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  TInterface1, TInterface2, TInterface3
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  TInterface1, TInterface2, TInterface3
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  TInterface1, TInterface2, TInterface3
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  TInterface1, TInterface2, TInterface3
+        {
+            dependencies.InstallFactoryBinding<TInterface1, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface2, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface3, TImpl>(customId, factoryImpl);
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  TInterface1, TInterface2, TInterface3
+        {
+            dependencies.InstallBindingInternal<TInterface1, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface2, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface3, TImpl>(customId, resolver);
+        }
+
+
+    }
+
+    public class DiBinder<TInterface1, TInterface2, TInterface3, TInterface4> : IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            dependencies.InstallFactoryBinding<TInterface1, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface2, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface3, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface4, TImpl>(customId, factoryImpl);
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            dependencies.InstallBindingInternal<TInterface1, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface2, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface3, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface4, TImpl>(customId, resolver);
+        }
+
+
+    }
+
+    public class DiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> : IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>
+    {
+        private readonly DiContainer dependencies;
+
+        private string customId;
+
+        public DiBinder(DiContainer dependencies)
+        {
+            this.dependencies = dependencies;
+        }
+
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> WithId(string id)
+        {
+            customId = id;
+            return this;
+        }
+
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            var resolver = new InstanceResolver<TImpl>(instance);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToNewInstance<TImpl>() where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            var resolver = new NewInstanceResolver<TImpl>(dependencies);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+            InstallBindings<TImpl>(resolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            InstallBindings<TImpl>(customResolver);
+            return dependencies;
+        }
+
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            dependencies.InstallFactoryBinding<TInterface1, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface2, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface3, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface4, TImpl>(customId, factoryImpl);
+            dependencies.InstallFactoryBinding<TInterface5, TImpl>(customId, factoryImpl);
+            return dependencies;
+        }
+
+        private void InstallBindings<TImpl>(IResolver resolver) where TImpl :  TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            dependencies.InstallBindingInternal<TInterface1, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface2, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface3, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface4, TImpl>(customId, resolver);
+            dependencies.InstallBindingInternal<TInterface5, TImpl>(customId, resolver);
+        }
+
+
+    }
+}

--- a/Runtime/DIContainer/Binders/DiBinders.g.cs.meta
+++ b/Runtime/DIContainer/Binders/DiBinders.g.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dd8a34397706bb4c9321f3e8bf76578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DIContainer/Binders/DiBindingInterfaces.g.cs
+++ b/Runtime/DIContainer/Binders/DiBindingInterfaces.g.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using UJect.Factories;
+using UJect.Resolvers;
+using Uject.Utilities;
+
+namespace UJect
+{
+
+    public interface IDiBinder<in TInterface1> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<TInterface1> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface1;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface1;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface1;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface1;
+    }
+
+    public interface IDiBinder<in TInterface1, in TInterface2> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<TInterface1, TInterface2> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface1, TInterface2;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface1, TInterface2;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface1, TInterface2;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface1, TInterface2;
+    }
+
+    public interface IDiBinder<in TInterface1, in TInterface2, in TInterface3> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<TInterface1, TInterface2, TInterface3> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface1, TInterface2, TInterface3;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface1, TInterface2, TInterface3;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface1, TInterface2, TInterface3;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface1, TInterface2, TInterface3;
+    }
+
+    public interface IDiBinder<in TInterface1, in TInterface2, in TInterface3, in TInterface4> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface1, TInterface2, TInterface3, TInterface4;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4;
+    }
+
+    public interface IDiBinder<in TInterface1, in TInterface2, in TInterface3, in TInterface4, in TInterface5> : IDiBinder
+    {
+        /// <summary>
+        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>The same binder</returns>
+        [LibraryEntryPoint]
+        IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> WithId(string id);
+        
+        /// <summary>
+        /// Bind the given type to a provided concrete implementation instance of that type.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5;
+        
+        /// <summary>
+        /// Bind the given type to a new instance of the provided concrete implementation of that type.
+        /// </summary>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5;
+        
+        /// <summary>
+        /// Bind the given type to a function that will provide a concrete instance of that type
+        /// </summary>
+        /// <param name="factoryMethod"></param>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5;
+        
+        /// <summary>
+        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+        /// create the instance.
+        /// </summary>
+        /// <param name="factoryImpl"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5;
+
+        /// <summary>
+        /// Bind the given type to a custom resolver.
+        /// </summary>
+        /// <param name="customResolver"></param>
+        /// <typeparam name="TImpl"></typeparam>
+        /// <returns>The original container</returns>
+        [LibraryEntryPoint]
+        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface1, TInterface2, TInterface3, TInterface4, TInterface5;
+    }
+}

--- a/Runtime/DIContainer/Binders/DiBindingInterfaces.g.cs.meta
+++ b/Runtime/DIContainer/Binders/DiBindingInterfaces.g.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da63eeae9187d5b4387fb83bfd1690ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/DIContainer/Container/DiContainer.Binding.cs
+++ b/Runtime/DIContainer/Container/DiContainer.Binding.cs
@@ -11,11 +11,38 @@ namespace UJect
         #region Public Binding Interface
 
         [LibraryEntryPoint]
-        public IDiBinder<TInterface> Bind<TInterface>()
+        public IDiBinder<TInterface1> Bind<TInterface1>()
         {
             RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<TInterface1>(this);
+        }
 
-            return new DiBinder<TInterface>(this);
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2> Bind<TInterface1, TInterface2>()
+        {
+            RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<TInterface1, TInterface2>(this);
+        }
+
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3> Bind<TInterface1, TInterface2, TInterface3>()
+        {
+            RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<TInterface1, TInterface2, TInterface3>(this);
+        }
+
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4> Bind<TInterface1, TInterface2, TInterface3, TInterface4>()
+        {
+            RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<TInterface1, TInterface2, TInterface3, TInterface4>(this);
+        }
+
+        [LibraryEntryPoint]
+        public IDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> Bind<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>()
+        {
+            RuntimeAssert.AssertIsFalse(isDisposed, "You should not try to bind to a disposed container!");
+            return new DiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>(this);
         }
 
         [LibraryEntryPoint]

--- a/Runtime/DIContainer/DIBinder.cs
+++ b/Runtime/DIContainer/DIBinder.cs
@@ -8,152 +8,96 @@ namespace UJect
     public interface IDiBinder
     {
     }
-    
-    public interface IDiBinder<in TInterface> : IDiBinder
-    {
-        /// <summary>
-        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns>The same binder</returns>
-        [LibraryEntryPoint]
-        IDiBinder<TInterface> WithId(string id);
-        
-        /// <summary>
-        /// Bind the given type to a provided concrete implementation instance of that type.
-        /// </summary>
-        /// <param name="instance"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface;
-        
-        /// <summary>
-        /// Bind the given type to a new instance of the provided concrete implementation of that type.
-        /// </summary>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        DiContainer ToNewInstance<TImpl>() where TImpl : TInterface;
-        
-        /// <summary>
-        /// Bind the given type to a function that will provide a concrete instance of that type
-        /// </summary>
-        /// <param name="factoryMethod"></param>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface;
-        
-        /// <summary>
-        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
-        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
-        /// create the instance.
-        /// </summary>
-        /// <param name="factoryImpl"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface;
 
-        /// <summary>
-        /// Bind the given type to a custom resolver.
-        /// </summary>
-        /// <param name="customResolver"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface;
-    }
-
-    public class DiBinder<TInterface> : IDiBinder<TInterface>
-    {
-        private readonly DiContainer dependencies;
-
-        private string customId;
-
-        public DiBinder(DiContainer dependencies)
-        {
-            this.dependencies = dependencies;
-        }
-
-        /// <summary>
-        /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
-        /// </summary>
-        /// <param name="id"></param>
-        /// <returns>The same binder</returns>
-        [LibraryEntryPoint]
-        public IDiBinder<TInterface> WithId(string id)
-        {
-            customId = id;
-            return this;
-        }
-
-        /// <summary>
-        /// Bind the given type to a provided concrete implementation instance of that type.
-        /// </summary>
-        /// <param name="instance"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface
-        {
-            var resolver = new InstanceResolver<TImpl>(instance);
-            dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
-            return dependencies;
-        }
-
-        /// <summary>
-        /// Bind the given type to a new instance of the provided concrete implementation of that type.
-        /// </summary>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        public DiContainer ToNewInstance<TImpl>() where TImpl : TInterface
-        {
-            var resolver = new NewInstanceResolver<TImpl>(dependencies);
-            dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
-            return dependencies;
-        }
-
-        /// <summary>
-        /// Bind the given type to a function that will provide a concrete instance of that type
-        /// </summary>
-        /// <param name="factoryMethod"></param>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface
-        {
-            var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
-            dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
-            return dependencies;
-        }
-
-        /// <summary>
-        /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
-        /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
-        /// create the instance.
-        /// </summary>
-        /// <param name="factoryImpl"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface
-        {
-            dependencies.InstallFactoryBinding<TInterface, TImpl>(customId, factoryImpl);
-            return dependencies;
-        }
-
-        /// <summary>
-        /// Bind the given type to a custom resolver.
-        /// </summary>
-        /// <param name="customResolver"></param>
-        /// <typeparam name="TImpl"></typeparam>
-        /// <returns>The original container</returns>
-        [LibraryEntryPoint]
-        public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface
-        {
-            dependencies.InstallBindingInternal<TInterface, TImpl>(customId, customResolver);
-            return dependencies;
-        }
-    }
+    // public class DiBinder<TInterface> : IDiBinder<TInterface>
+    // {
+    //     private readonly DiContainer dependencies;
+    //
+    //     private string customId;
+    //
+    //     public DiBinder(DiContainer dependencies)
+    //     {
+    //         this.dependencies = dependencies;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the type resource with the custom ID provided. This allows disambiguating multiple resources of the same type
+    //     /// </summary>
+    //     /// <param name="id"></param>
+    //     /// <returns>The same binder</returns>
+    //     [LibraryEntryPoint]
+    //     public IDiBinder<TInterface> WithId(string id)
+    //     {
+    //         customId = id;
+    //         return this;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the given type to a provided concrete implementation instance of that type.
+    //     /// </summary>
+    //     /// <param name="instance"></param>
+    //     /// <typeparam name="TImpl"></typeparam>
+    //     /// <returns>The original container</returns>
+    //     [LibraryEntryPoint]
+    //     public DiContainer ToInstance<TImpl>(TImpl instance) where TImpl : TInterface
+    //     {
+    //         var resolver = new InstanceResolver<TImpl>(instance);
+    //         dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
+    //         return dependencies;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the given type to a new instance of the provided concrete implementation of that type.
+    //     /// </summary>
+    //     /// <typeparam name="TImpl"></typeparam>
+    //     /// <returns>The original container</returns>
+    //     [LibraryEntryPoint]
+    //     public DiContainer ToNewInstance<TImpl>() where TImpl : TInterface
+    //     {
+    //         var resolver = new NewInstanceResolver<TImpl>(dependencies);
+    //         dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
+    //         return dependencies;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the given type to a function that will provide a concrete instance of that type
+    //     /// </summary>
+    //     /// <param name="factoryMethod"></param>
+    //     /// <returns>The original container</returns>
+    //     [LibraryEntryPoint]
+    //     public DiContainer ToFactoryMethod<TImpl>(Func<TImpl> factoryMethod) where TImpl : TInterface
+    //     {
+    //         var resolver = new FunctionInstanceResolver<TImpl>(factoryMethod);
+    //         dependencies.InstallBindingInternal<TInterface, TImpl>(customId, resolver);
+    //         return dependencies;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the given type to a factory implementation that will provide a concrete instance of that type.
+    //     /// Factories can be injected into before resolution, making them useful when you want to use a bunch of injected resources to
+    //     /// create the instance.
+    //     /// </summary>
+    //     /// <param name="factoryImpl"></param>
+    //     /// <typeparam name="TImpl"></typeparam>
+    //     /// <returns>The original container</returns>
+    //     [LibraryEntryPoint]
+    //     public DiContainer ToFactory<TImpl>(IInstanceFactory<TImpl> factoryImpl) where TImpl : TInterface
+    //     {
+    //         dependencies.InstallFactoryBinding<TInterface, TImpl>(customId, factoryImpl);
+    //         return dependencies;
+    //     }
+    //
+    //     /// <summary>
+    //     /// Bind the given type to a custom resolver.
+    //     /// </summary>
+    //     /// <param name="customResolver"></param>
+    //     /// <typeparam name="TImpl"></typeparam>
+    //     /// <returns>The original container</returns>
+    //     [LibraryEntryPoint]
+    //     public DiContainer ToCustomResolver<TImpl>(IResolver customResolver) where TImpl : TInterface
+    //     {
+    //         dependencies.InstallBindingInternal<TInterface, TImpl>(customId, customResolver);
+    //         return dependencies;
+    //     }
+    // }
 }

--- a/Tests/BindingTests/MultiBindTests.cs
+++ b/Tests/BindingTests/MultiBindTests.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2022 Eric Bennett McDuffee
+
+using System;
+using NUnit.Framework;
+using UJect.Exceptions;
+using UJect.Injection;
+
+namespace UJect.Tests
+{
+    [TestFixture]
+    public class MultiBindTests
+    {
+        [Test]
+        public void TestBindingMultipleInterfaces()
+        {
+            var container = new DiContainer();
+
+            container.Bind<IInterface1, IInterface2>().ToNewInstance<Impl12>();
+            container.TryResolveAll();
+
+            var impl1 = container.Get<IInterface1>();
+            var impl2 = container.Get<IInterface2>();
+
+            Assert.IsNotNull(impl1);
+            Assert.IsNotNull(impl2);
+            Assert.AreEqual(typeof(Impl12), impl1.GetType());
+            Assert.AreEqual(typeof(Impl12), impl2.GetType());
+            Assert.IsTrue(object.ReferenceEquals(impl1, impl2), "Should be using the same reference");
+        }
+
+        [Test]
+        public void TestDuplicateBinding()
+        {
+            var container = new DiContainer();
+
+            container.Bind<IInterface1, IInterface2>().ToNewInstance<Impl12>();
+            Assert.Throws<DuplicateBindingException>(() => container.Bind<IInterface1>().ToNewInstance<Impl12>());
+        }
+        
+        [Test]
+        public void TestMultiBindingDependsOnItself()
+        {
+            var container = new DiContainer();
+
+            Assert.Throws<CyclicDependencyException>(() => container.Bind<IInterface1, IInterface2>().ToNewInstance<Impl12_Broken>());
+        }
+
+        private interface IInterface1 { }
+
+        private interface IInterface2 { }
+
+        private class Impl12_Broken : IInterface1, IInterface2
+        {
+            [Inject]
+            private IInterface1 impl1;
+        }
+
+        private class Impl12 : IInterface1, IInterface2
+        {
+        }
+    }
+}

--- a/Tests/BindingTests/MultiBindTests.cs.meta
+++ b/Tests/BindingTests/MultiBindTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e4fce8a028484557a37add12ef628f3c
+timeCreated: 1669673454

--- a/UnityExtensions/ResourceBindings/ResourceInstanceResolver.cs
+++ b/UnityExtensions/ResourceBindings/ResourceInstanceResolver.cs
@@ -5,22 +5,6 @@ using UnityEngine;
 
 namespace UJect.UnityExtensions
 {
-    public static class UnityBinderExtensions
-    {
-        public static UnityDiBinder<TInterface> UnityBind<TInterface>(this DiContainer diContainer) => new UnityDiBinder<TInterface>(diContainer);
-    }
-
-    public class UnityDiBinder<TInterface> : DiBinder<TInterface>
-    {
-        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
-        
-        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl: Object, TInterface
-        {
-            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
-            return ToCustomResolver<TImpl>(resolver);
-        }
-    }
-
     internal class ResourceInstanceResolver<TImpl> : ResolverBase<TImpl> where TImpl : Object
     {
         private readonly string resourcePath;

--- a/UnityExtensions/ResourceBindings/UnityBinderExtensions.cs
+++ b/UnityExtensions/ResourceBindings/UnityBinderExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace UJect.UnityExtensions
+{
+    public static class UnityBinderExtensions
+    {
+        public static UnityDiBinder<TInterface1> UnityBind<TInterface1>(this DiContainer diContainer)
+            => new UnityDiBinder<TInterface1>(diContainer);
+
+        public static UnityDiBinder<TInterface1, TInterface2> UnityBind<TInterface1, TInterface2>(this DiContainer diContainer)
+            => new UnityDiBinder<TInterface1, TInterface2>(diContainer);
+
+        public static UnityDiBinder<TInterface1, TInterface2, TInterface3> UnityBind<TInterface1, TInterface2, TInterface3>(this DiContainer diContainer)
+            => new UnityDiBinder<TInterface1, TInterface2, TInterface3>(diContainer);
+
+        public static UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4> UnityBind<TInterface1, TInterface2, TInterface3, TInterface4>(this DiContainer diContainer)
+            => new UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4>(diContainer);
+
+        public static UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> UnityBind<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>(this DiContainer diContainer)
+            => new UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>(diContainer);
+    }
+}

--- a/UnityExtensions/ResourceBindings/UnityBinderExtensions.cs.meta
+++ b/UnityExtensions/ResourceBindings/UnityBinderExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: db414bc1b04344ba95f99268c17cd57c
+timeCreated: 1669740957

--- a/UnityExtensions/ResourceBindings/UnityDiBinder.cs
+++ b/UnityExtensions/ResourceBindings/UnityDiBinder.cs
@@ -1,0 +1,59 @@
+﻿using UnityEngine;
+
+namespace UJect.UnityExtensions
+{
+    public class UnityDiBinder<TInterface1> : DiBinder<TInterface1>
+    {
+        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
+
+        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl : Object, TInterface1
+        {
+            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
+            return ToCustomResolver<TImpl>(resolver);
+        }
+    }
+
+    public class UnityDiBinder<TInterface1, TInterface2> : DiBinder<TInterface1, TInterface2>
+    {
+        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
+
+        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl : Object, TInterface1, TInterface2
+        {
+            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
+            return ToCustomResolver<TImpl>(resolver);
+        }
+    }
+
+    public class UnityDiBinder<TInterface1, TInterface2, TInterface3> : DiBinder<TInterface1, TInterface2, TInterface3>
+    {
+        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
+
+        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl : Object, TInterface1, TInterface2, TInterface3
+        {
+            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
+            return ToCustomResolver<TImpl>(resolver);
+        }
+    }
+
+    public class UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4> : DiBinder<TInterface1, TInterface2, TInterface3, TInterface4>
+    {
+        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
+
+        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl : Object, TInterface1, TInterface2, TInterface3, TInterface4
+        {
+            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
+            return ToCustomResolver<TImpl>(resolver);
+        }
+    }
+
+    public class UnityDiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5> : DiBinder<TInterface1, TInterface2, TInterface3, TInterface4, TInterface5>
+    {
+        public UnityDiBinder(DiContainer dependencies) : base(dependencies) { }
+
+        public DiContainer ToResource<TImpl>(string resourcePath) where TImpl : Object, TInterface1, TInterface2, TInterface3, TInterface4, TInterface5
+        {
+            var resolver = new ResourceInstanceResolver<TImpl>(resourcePath);
+            return ToCustomResolver<TImpl>(resolver);
+        }
+    }
+}

--- a/UnityExtensions/ResourceBindings/UnityDiBinder.cs.meta
+++ b/UnityExtensions/ResourceBindings/UnityDiBinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3fd1b7d2b2fe412aad3fcf00c255da78
+timeCreated: 1669740076

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "UJect",
   "description": "Simple Unity Dependency Injection Library",
   "documentationUrl": "https://github.com/ericmcduffee/UJect",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "unity": "2019.2",
   "author": {
     "name": "Eric Bennett McDuffee",


### PR DESCRIPTION
Adds a new set of DI Binders that can bind multiple interfaces to the same implementation class.

For example:
```
void Initialize()
{
    container.Bind<IInterface1, IInterface2>()
        .ToNewInstance<Impl12>();
}

private interface IInterface1 { }

private interface IInterface2 { }

private class Impl12 : IInterface1, IInterface2
{
}
```


This required slightly changing the behavior of the NewInstanceResolver, but this shouldn't affect existing usages. Before it would create a new instance every time the interface was resolved. That made it impossible to reuse for multiple interfaces. So now it will resolve a single new instance and then reuse it.